### PR TITLE
[Fix] Fix S3 bucket name reference in getPresignedUrl function

### DIFF
--- a/src/service/s3.service.ts
+++ b/src/service/s3.service.ts
@@ -33,7 +33,7 @@ export const uploadResourceImageToS3 = async ( image: { path: string; mimetype: 
 };
 
 export const getPresignedUrl = async (key: string, type: "get" | "put" = "get", expiresInSec = 60): Promise<string> => {
-    const command = new GetObjectCommand({ Bucket: "process.env.AWS_S3_BUCKET", Key: key });
+    const command = new GetObjectCommand({ Bucket: process.env.AWS_S3_BUCKET, Key: key });
 
     const url = await getSignedUrl(S3, command, { expiresIn: expiresInSec });
     return url;


### PR DESCRIPTION
Replaced the hardcoded string with the correct environment variable for the S3 bucket name. This ensures the function uses the intended configuration and avoids potential issues with incorrect bucket references.