### PR TITLE
fix: Remove redundant trailing comma in SQL query

### DIFF
--- a/src/repository/tradeInfo.repository.ts
+++ b/src/repository/tradeInfo.repository.ts
@@ -110,7 +110,7 @@ export const getPurchasedResourcesInfo = async (userId: number): Promise<Resourc
             r.allow_derivation AS allowDerivation,
             ru.url AS imageUrl,
             g.id AS gameId,
-            g.title AS title,
+            g.title AS title
         FROM resource r
                  JOIN resource_transaction rt ON rt.resource_id = r.id
                  LEFT JOIN game g ON r.game_id = g.id


### PR DESCRIPTION
The trailing comma after "g.title AS title" was unnecessary and has been removed for cleaner and more accurate SQL formatting. This change ensures better compliance with standard SQL syntax and avoids potential issues or confusion in query interpretation.