### PR TITLE
fix: Fix typo in schema reference in tradeInfo route documentation

### DIFF
--- a/src/route/tradeInfo.route.ts
+++ b/src/route/tradeInfo.route.ts
@@ -132,7 +132,7 @@ const router: Router = Router();
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/Me ssageResponse'
+ *               $ref: '#/components/schemas/MessageResponse'
  */
 router.get('/tradeInfo', async (req: Request, res: Response) => {
     try {


### PR DESCRIPTION
Corrected the schema reference from "Me ssageResponse" to "MessageResponse" in the OpenAPI documentation for the tradeInfo route. This ensures accurate and proper generation of API documentation.