### PR TITLE
fix: Convert bigint to string for IDs in DTOs and entities.

### DIFF
--- a/src/dto/gameDetail.dto.ts
+++ b/src/dto/gameDetail.dto.ts
@@ -9,7 +9,7 @@ export interface GameDetailDto {
     thumbnailUrl: string;
     description: string;
     downloadTimes: number;
-    itemId: bigint;
+    itemId: string;
     registeredAt: Date;
     updatedAt: Date;
     tags: string[];            // 태그 문자열 배열

--- a/src/dto/gameTempDetail.dto.ts
+++ b/src/dto/gameTempDetail.dto.ts
@@ -7,7 +7,7 @@ export interface GameTempDetailDto {
     thumbnailUrl: string;
     description: string;
     downloadTimes: number;
-    itemId: bigint;
+    itemId: string;
     registeredAt: Date;
     updatedAt: Date;
 }

--- a/src/dto/resourceDetail.dto.ts
+++ b/src/dto/resourceDetail.dto.ts
@@ -8,7 +8,7 @@ export class ResourceDetailDto {
     additionalCondition: string | null;
     description: string | null;
     downloadTimes: number;
-    sharerId: bigint;
+    sharerId: string;
     registeredAt: Date;
     updatedAt: Date;
     imageUrls: string[];

--- a/src/dto/tradeInfoRawDto.ts
+++ b/src/dto/tradeInfoRawDto.ts
@@ -14,7 +14,7 @@ export interface GameTradeDto {
     price: string;
     description: string;
     thumbnailUrl: string;
-    itemId: bigint;
+    itemId: string;
     purchaseId: string;
     requirement: RequirementDto[];
 }
@@ -23,7 +23,7 @@ export interface ResourceTradeDto {
     resourceId: number;
     userId: number;
     description: string;
-    sharerId: number;
+    sharerId: string;
     sellerRatio: string;
     createrRatio: string;
     allowDerivation: boolean;
@@ -41,7 +41,7 @@ export interface TradeInfoRawDto {
     price: string;
     description: string;
     thumbnailUrl: string | null;
-    itemId: bigint;
+    itemId: string;
     isMinimum: boolean | null;
     os: string | null;
     cpu: string | null;

--- a/src/entity/game.entity.ts
+++ b/src/entity/game.entity.ts
@@ -19,8 +19,8 @@ export class Game {
     @Column({ name: 'user_id', type: 'int', default: 0 })
     userId: number;
 
-    @Column({ name: 'item_id', type: 'bigint', default: 0 })
-    itemId: bigint;
+    @Column({ name: 'item_id', type: 'varchar', length: 255 })
+    itemId: string;
 
     @Column({ type: 'decimal', precision: 10, scale: 2 })
     price: number;

--- a/src/entity/resource.entity.ts
+++ b/src/entity/resource.entity.ts
@@ -29,8 +29,8 @@ export class Resource {
     @Column({ name: 'download_times', type: 'int', default: () => '0' })
     downloadTimes: number;
 
-    @Column({ name: 'sharer_id', type: 'bigint', default: 0 })
-    sharerId: bigint;
+    @Column({ name: 'sharer_id', type: 'varchar', length: 255 })
+    sharerId: string;
 
     @CreateDateColumn({
         type: 'timestamp',


### PR DESCRIPTION
Replaced bigint with string for `itemId` and `sharerId` across relevant DTOs and entity definitions to standardize ID types. This ensures better compatibility with systems relying on string-based identifiers. Adjusted database column definitions accordingly.