### PR TITLE
[Feat] Add tag handling logic for games

### DIFF
--- a/src/dto/createGame.dto.ts
+++ b/src/dto/createGame.dto.ts
@@ -3,6 +3,7 @@ import {GameImageUrl} from "../entity/gameImageUrl.entity";
 import {GameTag} from "../entity/gameTag.entity";
 import {GameRequirement} from "../entity/gameRequirement.entity";
 import {OriginGame} from "../entity/originGame.entity";
+import {Tag} from "../entity/tag.entity";
 
 interface BaseGameDto {
     title: string;
@@ -108,4 +109,15 @@ export function toOriginGameEntities(createGameDto: CreateGameDto, gameId: numbe
         originGame.originGameId = originGameId;
         return originGame;
     });
+}
+
+export function toTagEntities(originGames: OriginGame[]) {
+    if (!originGames || originGames.length === 0) {
+        return [];
+    }
+    return originGames.map(originGame => {
+        const tag = new Tag();
+        tag.name = String(originGame.originGameId);
+        return tag;
+    })
 }

--- a/src/repository/game.repository.ts
+++ b/src/repository/game.repository.ts
@@ -40,6 +40,19 @@ export const updateGameFields = async (
     }
 };
 
+export async function findTitleById(gameId: number): Promise<string> {
+    const game = await gameRepo.findOne({
+        where: { id: gameId },
+        select: ['title']
+    });
+
+    if (!game) {
+        throw new Error(`Game with ID ${gameId} not found`);
+    }
+
+    return game.title;
+}
+
 export const findGameList = async(gameListRequestDto: GameListRequestDto): Promise<Game[]> =>{
     return await gameRepo.createQueryBuilder('game')
         .select(['game.id AS id', 'game.title AS title', 'game.thumbnail_url AS thumbnailUrl', 'game.item_id AS itemId'])

--- a/src/repository/tag.repository.ts
+++ b/src/repository/tag.repository.ts
@@ -1,0 +1,14 @@
+import {Tag} from "../entity/tag.entity";
+import AppDataSource from "../config/mysql.config";
+import {Repository} from "typeorm";
+
+const tagRepo: Repository<Tag> = AppDataSource.getRepository(Tag);
+
+export async function saveTag(tag: Tag): Promise<number> {
+    try {
+        return (await tagRepo.save(tag)).id;
+    } catch (error) {
+        console.error('Failed to save tag:', error);
+        throw new Error('Failed to save tag to database');
+    }
+}


### PR DESCRIPTION
Introduced functionality to process and save tags associated with games. This includes mapping origin game titles to tags, saving them in the database, and linking them to games via game-tag entities. Additional helper functions and repository methods were implemented to support this feature.