### PR TITLE
[Feat] Convert game title to lowercase before returning

### DIFF
--- a/src/repository/game.repository.ts
+++ b/src/repository/game.repository.ts
@@ -50,7 +50,7 @@ export async function findTitleById(gameId: number): Promise<string> {
         throw new Error(`Game with ID ${gameId} not found`);
     }
 
-    return game.title;
+    return game.title.toLowerCase();
 }
 
 export const findGameList = async(gameListRequestDto: GameListRequestDto): Promise<Game[]> =>{


### PR DESCRIPTION
Ensures consistent formatting of game titles by converting them to lowercase. This will help avoid case sensitivity issues in downstream processes or comparisons.