### PR TITLE
[Fix] Update Swagger server URL in configuration

### DIFF
--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -19,7 +19,7 @@ const options = {
     },
     servers: [
       {
-        url: 'http://3.37.46.45:30353',
+        url: 'http://16.184.9.194:30353',
         description: '게임 관리 API 서버'
       }
     ],


### PR DESCRIPTION
Changed the server URL to reflect the updated endpoint address. This ensures the Swagger documentation points to the correct API server for accessing game management features.