### PR TITLE
[Feat] Update search threshold in searchSimilarGames function

### DIFF
--- a/src/service/qdrant.service.ts
+++ b/src/service/qdrant.service.ts
@@ -43,7 +43,7 @@ export async function upsertGameEmbedding(gameId: number, embedding: number[]) {
     }
 }
 
-export async function searchSimilarGames(queryEmbedding: number[], threshold: number = 0.8) {
+export async function searchSimilarGames(queryEmbedding: number[], threshold: number = 0.3) {
     try {
         const result = await client.search('game', {
             vector: queryEmbedding,


### PR DESCRIPTION
Reduced the default threshold from 0.8 to 0.3 to retrieve a broader range of similar games. This adjustment improves the flexibility of similarity matching for diverse use cases.